### PR TITLE
fix: Updated so that I can use multi mocha reporters

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled":"list, xunit-file",
+  "xunitReporterOptions":{
+    "output":"xunit.xml"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2689,6 +2689,27 @@
         }
       }
     },
+    "mocha-multi-reporters": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+      "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "modify-values": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "npm run lint && npm run mocha",
     "lint": "eslint .",
-    "mocha": "nyc --reporter=lcov mocha --recursive -R xunit-file",
+    "mocha": "nyc --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=config.json",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "version": "standard-version"
   },
@@ -30,9 +30,10 @@
     "fs-extra": "^2.1.2",
     "jshint": "^2.9.4",
     "mocha": "^3.2.0",
+    "mocha-multi-reporters": "^1.1.7",
     "nyc": "^10.3.0",
-    "xunit-file": "^1.0.0",
     "standard-version": "^4.2.0",
+    "xunit-file": "^1.0.0",
     "yeoman-assert": "^2.2.2",
     "yeoman-test": "^1.7.0"
   },

--- a/xunit.xml
+++ b/xunit.xml
@@ -1,20 +1,32 @@
-<testsuite name="Mocha Tests" tests="20" failures="0" errors="0" skipped="0" timestamp="2018-04-07T00:48:35" time="0.812">
+<testsuite name="Mocha Tests" tests="32" failures="0" errors="0" skipped="0" timestamp="2018-05-02T20:00:37" time="1.124">
 <testcase classname="Web project generator Basic app with NodeJS" name="contains web pages" time="0"/>
-<testcase classname="Web project generator Basic app with NodeJS" name="starter text appears" time="0"/>
+<testcase classname="Web project generator Basic app with NodeJS" name="starter text appears" time="0.001"/>
 <testcase classname="Web project generator React app with NodeJS" name="required files created" time="0"/>
-<testcase classname="Web project generator React app with NodeJS" name="contains original dependencies" time="0.001"/>
-<testcase classname="Web project generator React app with NodeJS" name="contains Webpack" time="0"/>
+<testcase classname="Web project generator React app with NodeJS" name="contains original dependencies" time="0"/>
+<testcase classname="Web project generator React app with NodeJS" name="contains Webpack" time="0.001"/>
 <testcase classname="Web project generator React app with NodeJS" name="contains React" time="0"/>
-<testcase classname="Web project generator React app with NodeJS" name="should modify Dockerfile" time="0"/>
+<testcase classname="Web project generator React app with NodeJS" name="should modify Dockerfile" time="0.001"/>
 <testcase classname="Web project generator React app with NodeJS" name="should modify manifest.yml" time="0"/>
-<testcase classname="Web project generator AngularJS app with NodeJS and present existing files" name="required files created" time="0"/>
-<testcase classname="Web project generator AngularJS app with NodeJS and present existing files" name="contains original dependencies" time="0"/>
-<testcase classname="Web project generator AngularJS app with NodeJS and present existing files" name="should modify Dockerfile" time="0"/>
-<testcase classname="Web project generator AngularJS app with NodeJS and present existing files" name="should modify manifest.yml" time="0"/>
-<testcase classname="Web project generator AngularJS app with NodeJS and present existing files" name="should have react specific build script" time="0"/>
-<testcase classname="Web project generator AngularJS app with NodeJS and present existing files" name="should have original scripts and dependencies" time="0"/>
+<testcase classname="Web project generator React app with NodeJS using a defined node version" name="required files created" time="0"/>
+<testcase classname="Web project generator React app with NodeJS using a defined node version" name="should have package.json add node 8.0.0 to engines" time="0.001"/>
+<testcase classname="Web project generator React app with NodeJS using a defined node version" name="contains Webpack" time="0"/>
+<testcase classname="Web project generator React app with NodeJS using a defined node version" name="contains React" time="0"/>
+<testcase classname="Web project generator React app with NodeJS using a defined node version" name="should modify Dockerfile" time="0"/>
+<testcase classname="Web project generator React app with NodeJS using a defined node version" name="should modify manifest.yml" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS using a defined node version and present existing files " name="required files created" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS using a defined node version and present existing files " name="should have package.json add node 8.0.0 to  engines" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS using a defined node version and present existing files " name="should modify Dockerfile" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS using a defined node version and present existing files " name="should modify manifest.yml" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS using a defined node version and present existing files " name="should have react specific build script" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS using a defined node version and present existing files " name="should have original scripts and dependencies" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS and present existing files " name="required files created" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS and present existing files " name="contains original dependencies" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS and present existing files " name="should modify Dockerfile" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS and present existing files " name="should modify manifest.yml" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS and present existing files " name="should have react specific build script" time="0"/>
+<testcase classname="Web project generator AngularJS app with NodeJS and present existing files " name="should have original scripts and dependencies" time="0"/>
 <testcase classname="Web project generator AngularJS app with NodeJS with empty user directory" name="required files created" time="0"/>
-<testcase classname="Web project generator AngularJS app with NodeJS with empty user directory" name="contains original dependencies" time="0.001"/>
+<testcase classname="Web project generator AngularJS app with NodeJS with empty user directory" name="contains original dependencies" time="0"/>
 <testcase classname="Web project generator AngularJS app with NodeJS with empty user directory" name="should not have Dockerfile" time="0"/>
 <testcase classname="Web project generator AngularJS app with NodeJS with empty user directory" name="should not have manifest.yml" time="0"/>
 <testcase classname="Web project generator AngularJS app with NodeJS with empty user directory" name="should have react specific build script" time="0"/>


### PR DESCRIPTION
Now can use the standard "list" mocha reporter along with the "xunit" mocha reporter. This allows us to see the errors on the standard out and on the xunit file. Once this is accepted, we can push this out to all the other generators so that everyone can see errors to stdout.