### PR TITLE
fix(angular): change cdn link for core angular

### DIFF
--- a/generators/app/templates/angularjs/client/index.html
+++ b/generators/app/templates/angularjs/client/index.html
@@ -3,7 +3,7 @@
     <title>IBM Cloud Web Starter</title>
     <meta charset="UTF-8" />
 </head>
-<script src="https://opensource.keycdn.com/angularjs/1.6.6/angular.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.6.6/angular.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/1.0.3/angular-ui-router.min.js"></script>
 <body ng-app="App" ng-controller="MainCtrl">
     <div ui-view>You need to enable JavaScript to run this app.</div>


### PR DESCRIPTION
The old one https://opensource.keycdn.com/angularjs/1.6.6/angular.min.js was taken down